### PR TITLE
Make SP reslover something that can be overridden.

### DIFF
--- a/src/KnightSwarm/LaravelSaml/LaravelSamlServiceProvider.php
+++ b/src/KnightSwarm/LaravelSaml/LaravelSamlServiceProvider.php
@@ -34,9 +34,14 @@ class LaravelSamlServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
+        $this->app->bind('SamlSpReslover', function() {
+          return $this->app->config->get('laravel-saml::saml.sp_name', 'default-sp');
+        });
+
         $this->app->bind('Saml', function()
         {
-            $samlboot = new Saml\SamlBoot();
+            $sp_resolver = $this->app->make('SamlSpReslover');
+            $samlboot = new Saml\SamlBoot($sp_resolver);
             return $samlboot->getSimpleSaml();
         });
     }

--- a/src/KnightSwarm/LaravelSaml/Saml/SamlBoot.php
+++ b/src/KnightSwarm/LaravelSaml/Saml/SamlBoot.php
@@ -9,10 +9,10 @@ class SamlBoot {
     protected $sp;
     protected $saml;
 
-    public function __construct()
+    public function __construct($samlSpResolver)
     {
+        $this->sp_resolver = $samlSpResolver;
         $this->saml = $this->setupSimpleSaml();
-
     }
 
     public function getSimpleSaml()
@@ -24,7 +24,7 @@ class SamlBoot {
     protected function setupSimpleSaml()
     {
         $this->path = Config::get('laravel-saml::saml.sp_path', public_path()."/sp/www");
-        $this->sp   = Config::get('laravel-saml::saml.sp_name', 'default-sp');
+        $this->sp   = $this->sp_resolver;
 
         require_once($this->path.'/lib/_autoload.php');
 


### PR DESCRIPTION
This allows us to specify something that can resolve SPs rather than just having a setting. 
