### PR TITLE
Optionally pass redirect url to login-controller

### DIFF
--- a/src/controllers/SamlController.php
+++ b/src/controllers/SamlController.php
@@ -4,6 +4,7 @@ use KnightSwarm\LaravelSaml\Account;
 use \Saml;
 use \Auth;
 use \Session;
+use \Input;
 
 class SamlController extends BaseController {
 
@@ -25,8 +26,15 @@ class SamlController extends BaseController {
 
 	public function login()
 	{
+        if (Input::has('url')) {
+            // only allow local urls as redirect destinations
+            $url = Input::get('url');
+            if (!preg_match("~^(//|[^/]+:)~", $url)) {
+                Session::flash('url.intended', $url);
+            }
+        }
 
-    	if (!$this->account->samlLogged()) {
+        if (!$this->account->samlLogged()) {
             Auth::logout();
             $this->account->samlLogin();
         }


### PR DESCRIPTION
In my case I have a SPA that sends the user to the login page when the API returns a 401-code. When successfully logged in, instead of going to front page the user should go to the correct page, so passing `?url=xx` allows for this.