### PR TITLE
remove unnecessary use statements for non-namespaced controller

### DIFF
--- a/src/controllers/SamlController.php
+++ b/src/controllers/SamlController.php
@@ -1,10 +1,6 @@
 <?php
 
 use KnightSwarm\LaravelSaml\Account;
-use \Saml;
-use \Auth;
-use \Session;
-use \Input;
 
 class SamlController extends BaseController {
 


### PR DESCRIPTION
Changes introduced in php 5.6.9 throw an ErrorException when using unnecessary "use" statements in a non-namespaced class; see screenshot:
![screen shot 2015-10-30 at 17 19 18](https://cloud.githubusercontent.com/assets/1203675/10858334/7cb5a042-7f2a-11e5-85e8-4cf1b4122a90.png)