### PR TITLE
Configurable routes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         },
         {
             "name": "Tom Mount",
-            "email": "tmountjr@ebay.com"
+            "email": "tmountjr@gmail.com"
         },
         {
             "name": "Phil Preston",

--- a/src/config/saml.php
+++ b/src/config/saml.php
@@ -29,6 +29,14 @@ return array(
     'logout_target' => 'http://saml.dev',
 
     /*
+     * The route slugs to use for the login and logout controller methods
+     */
+    'routes' => array(
+        'login' => 'login',
+        'logout' => 'logout',
+    ),
+
+    /*
      * Internal id property, defaults to email.
      * The property to identify users by in the system.
      * 'internal_id_property' => 'email',

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,10 +1,7 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: diego
- * Date: 21/03/14
- * Time: 00:25
- */
 
-Route::get('login', 'SamlController@login');
-Route::get('logout', 'SamlController@logout');
+$loginRoute = Config::get('laravel-saml::saml.routes.login', 'login');
+$logoutRoute = Config::get('laravel-saml::saml.routes.logout', 'logout');
+
+Route::get($loginRoute, 'SamlController@login');
+Route::get($logoutRoute, 'SamlController@logout');


### PR DESCRIPTION
Found a need to change the routes supplied by default with the package, but there was no good way to do it without changing the package directly after requiring it, which is both against best practices and not possible in a deployment scenario. By putting the route slug in the config file, during the development process the user can run `php artisan config:publish knight-swarm/laravel-saml`, change the `routes` key, and commit the modified `app/config/packages/knight-swarm/laravel-saml/saml.php` to the repo. When his app is deployed, the configurable route will be downloaded and promptly overridden by the committed config file in the `app` directory.

By default and for backwards compatibility, this change maintains the existing `login` and `logout` slugs.